### PR TITLE
Update due to C++14

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: bmlm
 Title: Bayesian Multilevel Mediation
-Version: 1.3.7
-Date: 2018-07-11
+Version: 1.3.8
+Date: 2018-10-16
 Authors@R: person(given = "Matti", 
                   family = "Vuorre", 
                   email = "mv2521@columbia.edu",
@@ -14,10 +14,10 @@ License: GPL (>= 3)
 LazyData: true
 NeedsCompilation: yes
 Depends:
-    R (>= 3.0.2),
+    R (>= 3.4.0),
     Rcpp (>= 0.12.0)
 Imports:
-    rstan (>= 2.12.1),
+    rstan (>= 2.18.1),
     ggplot2 (>= 2.0.0),
     methods
 Suggests:
@@ -27,9 +27,9 @@ Suggests:
     reshape2,
     dplyr
 LinkingTo:
-    StanHeaders (>= 2.12.0),
-    rstan (>= 2.12.1),
-    BH (>= 1.60.0),
+    StanHeaders (>= 2.18.0),
+    rstan (>= 2.18.1),
+    BH (>= 1.66.0),
     Rcpp (>= 0.12.0),
     RcppEigen
 RoxygenNote: 6.0.1

--- a/cleanup
+++ b/cleanup
@@ -6,7 +6,6 @@ mkdir -p src/include
 sed -i.bak '/current_statement_begin__ = [0-9]/d' src/include/models.hpp
 cat src/*.cc > src/Modules.cpp
 rm src/*.cc
-"${R_HOME}/bin/R" --vanilla --slave -e 'roxygen2::roxygenize(clean = TRUE)'
 exit $?
 
 

--- a/cleanup.win
+++ b/cleanup.win
@@ -6,7 +6,6 @@ mkdir -p src/include
 sed -i.bak '/current_statement_begin__ = [0-9]/d' src/include/models.hpp
 cat src/*.cc > src/Modules.cpp
 rm src/*.cc
-"${R_HOME}/bin/R" --vanilla --slave -e 'roxygen2::roxygenize(clean = TRUE)'
 exit $?
 
 

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,4 +1,4 @@
 STANHEADERS_SRC = `"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" --vanilla -e "cat(system.file('include', 'src', package = 'StanHeaders'))"`
 BOOST_NOT_IN_BH_SRC = `"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" --vanilla -e "cat(system.file('include', 'boost_not_in_BH', package = 'rstan'))"`
 PKG_CPPFLAGS = -I"$(STANHEADERS_SRC)" -I"$(BOOST_NOT_IN_BH_SRC)" -DBOOST_RESULT_OF_USE_TR1 -DBOOST_NO_DECLTYPE -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_NO_CXX11_RVALUE_REFERENCES
-CXX_STD = CXX11
+CXX_STD = CXX14


### PR DESCRIPTION
This PR allows your package to build with rstan 2.18.1 on CRAN, which requires C++14. I have run R CMD check on your package from a Debian system similar to that on CRAN and uploaded the tarball to https://win-builder.r-project.org/ so the package maintainer should soon see the result of running R CMD check on Windows.

If you have questions or issues, please post at
https://discourse.mc-stan.org/t/how-to-update-a-package-that-has-stanheaders-and-rstan-in-its-linkingto/6041?u=bgoodri
rather than, or in addition to, this PR so that other maintainers of R packages that use Stan can benefit from your experience.

If all goes well with the R CMD check, please upload a new version to CRAN soon before your package gets kicked out.