### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Imports:
     ggplot2 (>= 2.0.0),
     methods,
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.18.1),
+    rstan (>= 2.26.0),
     rstantools (>= 2.3.1.1)
 Suggests:
     qgraph,
@@ -33,8 +33,8 @@ LinkingTo:
     Rcpp (>= 0.12.0),
     RcppEigen (>= 0.3.3.3.0),
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.18.1),
-    StanHeaders (>= 2.18.0)
+    rstan (>= 2.26.0),
+    StanHeaders (>= 2.26.0)
 RoxygenNote: 7.1.2
 Encoding: UTF-8
 SystemRequirements: GNU make

--- a/inst/stan/bmlm_binary_y.stan
+++ b/inst/stan/bmlm_binary_y.stan
@@ -2,7 +2,7 @@
 
 data {
 #include chunks/data.stan
-    int<lower=0, upper=1> Y[N]; // Dichotomous outcome
+  array[N]  int<lower=0, upper=1> Y; // Dichotomous outcome
 }
 transformed data{
 #include chunks/transformed_data.stan

--- a/inst/stan/chunks/data.stan
+++ b/inst/stan/chunks/data.stan
@@ -1,6 +1,6 @@
     int<lower=1> N;             // Number of observations
     int<lower=1> J;             // Number of participants
-    int<lower=1,upper=J> id[N]; // Participant IDs
+    array[N] int<lower=1,upper=J> id; // Participant IDs
     vector[N] X;                // Manipulated variable
     vector[N] M;                // Mediator
     // Priors


### PR DESCRIPTION
Apologies for requesting additional changes so soon! These don't need to go in urgently (still one major release of rstan before these will be an issue), so no pressure on risking CRAN's ire by submitting updates too frequently!

Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html


Let me know if you have any questions about these changes.

Thanks!
